### PR TITLE
Bugfix/uninitialized cpu codec platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Get the seeed voice card source code. and install all linux kernel drivers
 ```bash
 git clone https://github.com/respeaker/seeed-voicecard
 cd seeed-voicecard
-sudo ./install.sh 
+sudo ./install.sh
 sudo reboot
 ```
+It may probably happen that the driver won't compile with the latest kernel when raspbian rolls out new patches to the kernel. If so, please try `sudo ./install.sh --compat-kernel` which uses an older kernel but ensures that the driver can work. 
 
 ## ReSpeaker Mic Hat
 

--- a/ac108.c
+++ b/ac108.c
@@ -865,7 +865,7 @@ static int ac108_set_fmt(struct snd_soc_dai *dai, unsigned int fmt) {
 			/* TODO: Both cpu_dai and codec_dai(AC108) be set as slave in DTS */
 			dev_dbg(dai->dev, "used as slave when AC101 is master\n");
 		}
-		/* fall through */
+		fallthrough;
 	case SND_SOC_DAIFMT_CBS_CFS:    /*AC108 Slave*/
 		dev_dbg(dai->dev, "AC108 set to work as Slave\n");
 		/**

--- a/ac108.c
+++ b/ac108.c
@@ -865,6 +865,7 @@ static int ac108_set_fmt(struct snd_soc_dai *dai, unsigned int fmt) {
 			/* TODO: Both cpu_dai and codec_dai(AC108) be set as slave in DTS */
 			dev_dbg(dai->dev, "used as slave when AC101 is master\n");
 		}
+		/* fall through */
 	case SND_SOC_DAIFMT_CBS_CFS:    /*AC108 Slave*/
 		dev_dbg(dai->dev, "AC108 set to work as Slave\n");
 		/**

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-FORCE_KERNEL="1.20190925+1-1"
-
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root (use sudo)" 1>&2
    exit 1
@@ -92,43 +90,12 @@ function check_kernel_headers() {
   apt-get -y --reinstall install raspberrypi-kernel
 }
 
-function download_install_debpkg() {
-  local prefix name r
-  prefix=$1
-  name=$2
-
-  for (( i = 0; i < 3; i++ )); do
-    wget $prefix$name -O /tmp/$name && break
-  done
-  dpkg -i /tmp/$name; r=$?
-  rm -f /tmp/$name
-  return $r
-}
-
-function install_kernel() {
-  local _url _prefix
-
-   # Instead of retriving the lastest kernel & headers
-  [ "X$FORCE_KERNEL" == "X" ] && {
-    apt-get -y --force-yes install raspberrypi-kernel-headers raspberrypi-kernel
-  } || {
-    # We would like to a fixed version
-    KERN_NAME=raspberrypi-kernel_${FORCE_KERNEL}_armhf.deb
-    HDR_NAME=raspberrypi-kernel-headers_${FORCE_KERNEL}_armhf.deb
-    _url=$(apt-get download --print-uris raspberrypi-kernel | sed -nre "s/'([^']+)'.*$/\1/g;p")
-    _prefix=$(echo $_url | sed -nre 's/^(.*)raspberrypi-kernel_.*$/\1/g;p')
-
-    download_install_debpkg "$_prefix" "$KERN_NAME"
-    download_install_debpkg "$_prefix" "$HDR_NAME"
-  }
-}
-
 # update and install required packages
 which apt &>/dev/null
 if [[ $? -eq 0 ]]; then
   apt update -y
+  apt-get -y install raspberrypi-kernel-headers raspberrypi-kernel 
   apt-get -y install dkms git i2c-tools libasound2-plugins
-  install_kernel
   # rpi-update checker
   check_kernel_headers
 fi

--- a/seeed-voicecard
+++ b/seeed-voicecard
@@ -115,7 +115,6 @@ if [ "$overlay" ]; then
     rm /etc/asound.conf
     rm /var/lib/alsa/asound.state
 
-: <<\EOF
     kernel_ver=$(get_kernel_version)
     # echo kernel_ver=$kernel_ver
 
@@ -131,7 +130,6 @@ if [ "$overlay" ]; then
             fi
         done
     fi
-EOF
     #make sure the driver loads correctly
     dtoverlay $overlay || true
 

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -378,7 +378,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 		goto dai_link_of_err;
 
 	#if _SINGLE_CODEC
-	ret = asoc_simple_canonicalize_dailink(dai_link);
+	ret = asoc_simple_canonicalize_platform(dai_link);
 	if (ret < 0)
 		goto dai_link_of_err;
 	#endif

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -252,26 +252,6 @@ static struct snd_soc_ops seeed_voice_card_ops = {
 	.trigger = seeed_voice_card_trigger,
 };
 
-static int seeed_voice_card_dai_init(struct snd_soc_pcm_runtime *rtd)
-{
-	struct seeed_card_data *priv =	snd_soc_card_get_drvdata(rtd->card);
-	struct snd_soc_dai *codec = rtd->codec_dai;
-	struct snd_soc_dai *cpu = rtd->cpu_dai;
-	struct seeed_dai_props *dai_props =
-		seeed_priv_to_props(priv, rtd->num);
-	int ret;
-
-	ret = asoc_simple_init_dai(codec, &dai_props->codec_dai);
-	if (ret < 0)
-		return ret;
-
-	ret = asoc_simple_init_dai(cpu, &dai_props->cpu_dai);
-	if (ret < 0)
-		return ret;
-
-	return 0;
-}
-
 static int seeed_voice_card_dai_link_of(struct device_node *node,
 					struct seeed_card_data *priv,
 					int idx,
@@ -393,7 +373,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 		goto dai_link_of_err;
 
 	dai_link->ops = &seeed_voice_card_ops;
-	dai_link->init = seeed_voice_card_dai_init;
+	dai_link->init = asoc_simple_dai_init;
 
 	dev_dbg(dev, "\tname : %s\n", dai_link->stream_name);
 	dev_dbg(dev, "\tformat : %04x\n", dai_link->dai_fmt);
@@ -592,7 +572,7 @@ static int seeed_voice_card_probe(struct platform_device *pdev)
 		dai_link->cpu_dai_name	= cinfo->cpu_dai.name;
 		dai_link->codec_dai_name = cinfo->codec_dai.name;
 		dai_link->dai_fmt	= cinfo->daifmt;
-		dai_link->init		= seeed_voice_card_dai_init;
+		dai_link->init		= asoc_simple_dai_init;
 		memcpy(&priv->dai_props->cpu_dai, &cinfo->cpu_dai,
 					sizeof(priv->dai_props->cpu_dai));
 		memcpy(&priv->dai_props->codec_dai, &cinfo->codec_dai,

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -362,9 +362,9 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 
 	ret = asoc_simple_set_dailink_name(dev, dai_link,
 						"%s-%s",
-						dai_link->cpu_dai_name,
+						dai_link->cpus->dai_name,
 						#if _SINGLE_CODEC
-						dai_link->codec_dai_name
+						dai_link->codecs->dai_name
 						#else
 						dai_link->codecs[0].dai_name
 						#endif
@@ -378,11 +378,11 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 	dev_dbg(dev, "\tname : %s\n", dai_link->stream_name);
 	dev_dbg(dev, "\tformat : %04x\n", dai_link->dai_fmt);
 	dev_dbg(dev, "\tcpu : %s / %d\n",
-		dai_link->cpu_dai_name,
+		dai_link->cpus->dai_name,
 		dai_props->cpu_dai.sysclk);
 	dev_dbg(dev, "\tcodec : %s / %d\n",
 		#if _SINGLE_CODEC
-		dai_link->codec_dai_name,
+		dai_link->codecs->dai_name,
 		#else
 		dai_link->codecs[0].dai_name,
 		#endif
@@ -567,10 +567,10 @@ static int seeed_voice_card_probe(struct platform_device *pdev)
 		priv->snd_card.name	= (cinfo->card) ? cinfo->card : cinfo->name;
 		dai_link->name		= cinfo->name;
 		dai_link->stream_name	= cinfo->name;
-		dai_link->platform_name	= cinfo->platform;
-		dai_link->codec_name	= cinfo->codec;
-		dai_link->cpu_dai_name	= cinfo->cpu_dai.name;
-		dai_link->codec_dai_name = cinfo->codec_dai.name;
+		dai_link->platforms->name	= cinfo->platform;
+		dai_link->codecs->name	= cinfo->codec;
+		dai_link->cpus->dai_name	= cinfo->cpu_dai.name;
+		dai_link->codecs->dai_name = cinfo->codec_dai.name;
 		dai_link->dai_fmt	= cinfo->daifmt;
 		dai_link->init		= asoc_simple_dai_init;
 		memcpy(&priv->dai_props->cpu_dai, &cinfo->cpu_dai,

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -261,11 +261,11 @@ static int seeed_voice_card_dai_init(struct snd_soc_pcm_runtime *rtd)
 		seeed_priv_to_props(priv, rtd->num);
 	int ret;
 
-	ret = asoc_simple_card_init_dai(codec, &dai_props->codec_dai);
+	ret = asoc_simple_init_dai(codec, &dai_props->codec_dai);
 	if (ret < 0)
 		return ret;
 
-	ret = asoc_simple_card_init_dai(cpu, &dai_props->cpu_dai);
+	ret = asoc_simple_init_dai(cpu, &dai_props->cpu_dai);
 	if (ret < 0)
 		return ret;
 
@@ -314,20 +314,20 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 		goto dai_link_of_err;
 	}
 
-	ret = asoc_simple_card_parse_daifmt(dev, node, codec,
+	ret = asoc_simple_parse_daifmt(dev, node, codec,
 					    prefix, &dai_link->dai_fmt);
 	if (ret < 0)
 		goto dai_link_of_err;
 
 	of_property_read_u32(node, "mclk-fs", &dai_props->mclk_fs);
 
-	ret = asoc_simple_card_parse_cpu(cpu, dai_link,
+	ret = asoc_simple_parse_cpu(cpu, dai_link,
 					 DAI, CELL, &single_cpu);
 	if (ret < 0)
 		goto dai_link_of_err;
 
 	#if _SINGLE_CODEC
-	ret = asoc_simple_card_parse_codec(codec, dai_link, DAI, CELL);
+	ret = asoc_simple_parse_codec(codec, dai_link, DAI, CELL);
 	if (ret < 0)
 		goto dai_link_of_err;
 	#else
@@ -339,7 +339,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 	dev_dbg(dev, "dai_link num_codecs = %d\n", dai_link->num_codecs);
 	#endif
 
-	ret = asoc_simple_card_parse_platform(plat, dai_link, DAI, CELL);
+	ret = asoc_simple_parse_platform(plat, dai_link, DAI, CELL);
 	if (ret < 0)
 		goto dai_link_of_err;
 
@@ -362,28 +362,28 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 		goto dai_link_of_err;
 
 	#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,10,0)
-	ret = asoc_simple_card_parse_clk_cpu(cpu, dai_link, cpu_dai);
+	ret = asoc_simple_parse_clk_cpu(cpu, dai_link, cpu_dai);
 	#else
-	ret = asoc_simple_card_parse_clk_cpu(dev, cpu, dai_link, cpu_dai);
+	ret = asoc_simple_parse_clk_cpu(dev, cpu, dai_link, cpu_dai);
 	#endif
 	if (ret < 0)
 		goto dai_link_of_err;
 
 	#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,10,0)
-	ret = asoc_simple_card_parse_clk_codec(codec, dai_link, codec_dai);
+	ret = asoc_simple_parse_clk_codec(codec, dai_link, codec_dai);
 	#else
-	ret = asoc_simple_card_parse_clk_codec(dev, codec, dai_link, codec_dai);
+	ret = asoc_simple_parse_clk_codec(dev, codec, dai_link, codec_dai);
 	#endif
 	if (ret < 0)
 		goto dai_link_of_err;
 
 	#if _SINGLE_CODEC
-	ret = asoc_simple_card_canonicalize_dailink(dai_link);
+	ret = asoc_simple_canonicalize_dailink(dai_link);
 	if (ret < 0)
 		goto dai_link_of_err;
 	#endif
 
-	ret = asoc_simple_card_set_dailink_name(dev, dai_link,
+	ret = asoc_simple_set_dailink_name(dev, dai_link,
 						"%s-%s",
 						dai_link->cpu_dai_name,
 						#if _SINGLE_CODEC
@@ -411,7 +411,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 		#endif
 		dai_props->codec_dai.sysclk);
 
-	asoc_simple_card_canonicalize_cpu(dai_link, single_cpu);
+	asoc_simple_canonicalize_cpu(dai_link, single_cpu);
 
 dai_link_of_err:
 	of_node_put(cpu);
@@ -503,7 +503,7 @@ static int seeed_voice_card_parse_of(struct device_node *node,
 			goto card_parse_end;
 	}
 
-	ret = asoc_simple_card_parse_card_name(&priv->snd_card, PREFIX);
+	ret = asoc_simple_parse_card_name(&priv->snd_card, PREFIX);
 	if (ret < 0)
 		goto card_parse_end;
 
@@ -615,7 +615,7 @@ static int seeed_voice_card_probe(struct platform_device *pdev)
 		return ret;
 
 err:
-	asoc_simple_card_clean_reference(&priv->snd_card);
+	asoc_simple_clean_reference(&priv->snd_card);
 
 	return ret;
 }
@@ -627,7 +627,7 @@ static int seeed_voice_card_remove(struct platform_device *pdev)
 
 	if (cancel_work_sync(&priv->work_codec_clk) != 0) {
 	}
-	return asoc_simple_card_clean_reference(card);
+	return asoc_simple_clean_reference(card);
 }
 
 static const struct of_device_id seeed_voice_of_match[] = {

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -420,7 +420,7 @@ static int seeed_voice_card_parse_aux_devs(struct device_node *node,
 		aux_node = of_parse_phandle(node, PREFIX "aux-devs", i);
 		if (!aux_node)
 			return -EINVAL;
-		priv->snd_card.aux_dev[i].codec_of_node = aux_node;
+		priv->snd_card.aux_dev[i].dlc.of_node = aux_node;
 	}
 
 	priv->snd_card.num_aux_devs = n;

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -378,9 +378,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 		goto dai_link_of_err;
 
 	#if _SINGLE_CODEC
-	ret = asoc_simple_canonicalize_platform(dai_link);
-	if (ret < 0)
-		goto dai_link_of_err;
+	asoc_simple_canonicalize_platform(dai_link);
 	#endif
 
 	ret = asoc_simple_set_dailink_name(dev, dai_link,

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -252,6 +252,55 @@ static struct snd_soc_ops seeed_voice_card_ops = {
 	.trigger = seeed_voice_card_trigger,
 };
 
+static int asoc_simple_parse_dai(struct device_node *node,
+				 struct snd_soc_dai_link_component *dlc,
+				 int *is_single_link)
+{
+	struct of_phandle_args args;
+	int ret;
+
+	if (!node)
+		return 0;
+
+	/*
+	 * Get node via "sound-dai = <&phandle port>"
+	 * it will be used as xxx_of_node on soc_bind_dai_link()
+	 */
+	ret = of_parse_phandle_with_args(node, DAI, CELL, 0, &args);
+	if (ret)
+		return ret;
+
+	/*
+	 * FIXME
+	 *
+	 * Here, dlc->dai_name is pointer to CPU/Codec DAI name.
+	 * If user unbinded CPU or Codec driver, but not for Sound Card,
+	 * dlc->dai_name is keeping unbinded CPU or Codec
+	 * driver's pointer.
+	 *
+	 * If user re-bind CPU or Codec driver again, ALSA SoC will try
+	 * to rebind Card via snd_soc_try_rebind_card(), but because of
+	 * above reason, it might can't bind Sound Card.
+	 * Because Sound Card is pointing to released dai_name pointer.
+	 *
+	 * To avoid this rebind Card issue,
+	 * 1) It needs to alloc memory to keep dai_name eventhough
+	 *    CPU or Codec driver was unbinded, or
+	 * 2) user need to rebind Sound Card everytime
+	 *    if he unbinded CPU or Codec.
+	 */
+	ret = snd_soc_of_get_dai_name(node, &dlc->dai_name);
+	if (ret < 0)
+		return ret;
+
+	dlc->of_node = args.np;
+
+	if (is_single_link)
+		*is_single_link = !args.args_count;
+
+	return 0;
+}
+
 static int seeed_voice_card_dai_link_of(struct device_node *node,
 					struct seeed_card_data *priv,
 					int idx,

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -321,13 +321,12 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 
 	of_property_read_u32(node, "mclk-fs", &dai_props->mclk_fs);
 
-	ret = asoc_simple_parse_cpu(cpu, dai_link,
-					 DAI, CELL, &single_cpu);
+	ret = asoc_simple_parse_cpu(cpu, dai_link, &single_cpu);
 	if (ret < 0)
 		goto dai_link_of_err;
 
 	#if _SINGLE_CODEC
-	ret = asoc_simple_parse_codec(codec, dai_link, DAI, CELL);
+	ret = asoc_simple_parse_codec(codec, dai_link);
 	if (ret < 0)
 		goto dai_link_of_err;
 	#else
@@ -339,7 +338,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 	dev_dbg(dev, "dai_link num_codecs = %d\n", dai_link->num_codecs);
 	#endif
 
-	ret = asoc_simple_parse_platform(plat, dai_link, DAI, CELL);
+	ret = asoc_simple_parse_platform(plat, dai_link);
 	if (ret < 0)
 		goto dai_link_of_err;
 

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -28,6 +28,8 @@
 #include <sound/simple_card_utils.h>
 #include "ac10x.h"
 
+#define LINUX_VERSION_IS_GEQ(x1,x2,x3)	(LINUX_VERSION_CODE >= KERNEL_VERSION(x1,x2,x3))
+
 /*
  * single codec:
  *	0 - allow multi codec

--- a/sound-compatible-4.18.h
+++ b/sound-compatible-4.18.h
@@ -15,6 +15,14 @@
 #define __NO_SND_SOC_CODEC_DRV     0
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
+#if __has_attribute(__fallthrough__)
+# define fallthrough                    __attribute__((__fallthrough__))
+#else
+# define fallthrough                    do {} while (0)  /* fallthrough */
+#endif
+#endif
+
 #if __NO_SND_SOC_CODEC_DRV
 #define codec                      component
 #define snd_soc_codec              snd_soc_component

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -73,9 +73,9 @@ echo "remove dkms"
 rm  -rf /var/lib/dkms/seeed-voicecard || true
 
 echo "remove kernel modules"
-rm  /lib/modules/${uname_r}/kernel/sound/soc/codecs/snd-soc-wm8960.ko || true
-rm  /lib/modules/${uname_r}/kernel/sound/soc/codecs/snd-soc-ac108.ko || true
-rm  /lib/modules/${uname_r}/kernel/sound/soc/bcm/snd-soc-seeed-voicecard.ko || true
+rm  /lib/modules/*/kernel/sound/soc/codecs/snd-soc-wm8960.ko || true
+rm  /lib/modules/*/kernel/sound/soc/codecs/snd-soc-ac108.ko || true
+rm  /lib/modules/*/kernel/sound/soc/bcm/snd-soc-seeed-voicecard.ko || true
 
 echo "remove $CONFIG configuration"
 for i in $RPI_HATS; do

--- a/wm8960.c
+++ b/wm8960.c
@@ -752,8 +752,8 @@ static int wm8960_hw_params(struct snd_pcm_substream *substream,
 		if ((iface & 0x3) != 0) {
 			iface |= 0x000c;
 			break;
-		};
-		/* fall through */
+		}
+		fallthrough;
 	default:
 		dev_err(codec->dev, "unsupported width %d\n",
 			params_width(params));

--- a/wm8960.c
+++ b/wm8960.c
@@ -752,7 +752,8 @@ static int wm8960_hw_params(struct snd_pcm_substream *substream,
 		if ((iface & 0x3) != 0) {
 			iface |= 0x000c;
 			break;
-		}
+		};
+		/* fall through */
 	default:
 		dev_err(codec->dev, "unsupported width %d\n",
 			params_width(params));


### PR DESCRIPTION
Commit 37a37a6d1645da7a83957b358ef73857161f114f moved to "modern style dai_link". However, for doing so adi_link->cpus etc. needs to be provided with backing storage. This is not  done automatically, at least not in 5.4. Please compare ```KERNEL/sound/soc/generic/simple-card-utils.c```, function ```asoc_simple_init_priv()```. Without this patch module loading immediately result in NULL-pointer dereference.