### PR TITLE
fix channel ordering

### DIFF
--- a/ac101.c
+++ b/ac101.c
@@ -1280,11 +1280,13 @@ int ac101_trigger(struct snd_pcm_substream *substream, int cmd,
 			ret = ret || ac101_update_bits(codec, MOD_RST_CTRL, (0x1<<MOD_RESET_AIF1), (0x1<<MOD_RESET_AIF1));
 		}
 		spin_unlock_irqrestore(&ac10x->lock, flags);
+		ac101_set_clock(1, substream, cmd, dai);
 		#endif
 		break;
 	case SNDRV_PCM_TRIGGER_STOP:
 	case SNDRV_PCM_TRIGGER_SUSPEND:
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
+		ac101_set_clock(0, NULL, 0, NULL);
 		break;
 	default:
 		ret = -EINVAL;

--- a/ac108.c
+++ b/ac108.c
@@ -999,7 +999,7 @@ static int ac108_set_clock(int y_start_n_stop, struct snd_pcm_substream *substre
 
 	/* spin_lock move to machine trigger */
 
-	if (y_start_n_stop && ac10x->i2c101 && _MASTER_MULTI_CODEC == _MASTER_AC101) {
+	if (ac10x->i2c101 && _MASTER_MULTI_CODEC == _MASTER_AC101) {
 		ac101_trigger(substream, cmd, dai);
 	}
 	if (y_start_n_stop && ac10x->sysclk_en == 0) {
@@ -1073,15 +1073,12 @@ static int ac108_trigger(struct snd_pcm_substream *substream, int cmd,
 			ac108_multi_update_bits(I2S_CTRL, 0x1 << TXEN | 0x1 << GEN, 0x0 << TXEN | 0x0 << GEN, ac10x);
 		}
 		spin_unlock_irqrestore(&ac10x->lock, flags);
-
-		/* delayed clock starting, move to machine trigger() */
+		ac108_set_clock(1, substream, cmd, dai);
 		break;
 	case SNDRV_PCM_TRIGGER_STOP:
 	case SNDRV_PCM_TRIGGER_SUSPEND:
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
-		if (ac10x->i2c101 && _MASTER_MULTI_CODEC == _MASTER_AC101) {
-			ac101_trigger(substream, cmd, dai);
-		}
+		ac108_set_clock(0, substream, cmd, dai);
 		break;
 	default:
 		ret = -EINVAL;

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -231,8 +231,8 @@ static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd
 		/* I know it will degrades performance, but I have no choice */
 		spin_lock_irqsave(&priv->lock, flags);
 		#endif
-		if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](1, substream, cmd, dai);
-		if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](1, substream, cmd, dai);
+		// if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](1, substream, cmd, dai);
+		// if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](1, substream, cmd, dai);
 		#if CONFIG_AC10X_TRIG_LOCK
 		spin_unlock_irqrestore(&priv->lock, flags);
 		#endif
@@ -252,8 +252,8 @@ static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd
 			if (0 != schedule_work(&priv->work_codec_clk)) {
 			}
 		} else {
-			if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
-			if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
+			// if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
+			// if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
 		}
 		break;
 	default:


### PR DESCRIPTION
This is an attempt to address https://github.com/respeaker/seeed-voicecard/issues/309

It's an improvement on the patch proposed here https://github.com/respeaker/seeed-voicecard/issues/309#issuecomment-989912874

As far as I understand it the idea was to change the clock in the ac108 (input) driver instead of the seeed-voicecard which combines the two.

The problem is that (as the initial change was written) it was getting rid also of the clock change for the ac101 (output) without doing it anywhere else. This lead to broken output. (at least on my respeaker 6 mic)

Also now that we're doing `ac108_set_clock(0, substream, cmd, dai);` in the `SNDRV_PCM_TRIGGER_PAUSE_PUSH` event, there's no need to call `ac101_trigger(substream, cmd, dai)` explicitly since this is done anyway inside the `ac108_set_clock` function.

I tested this code and I'm consistently getting the two loopback channels at the end of the 8 inputs.