### PR TITLE
fix detection of kernel modules on 64-bit image

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ function get_kernel_version() {
 
 function check_kernel_headers() {
   VER_RUN=$(get_kernel_version)
-  VER_HDR=$(dpkg -L raspberrypi-kernel-headers | egrep -m1 "/lib/modules/[^-]+/build" | awk -F'/' '{ print $4; }')
+  VER_HDR=$(dpkg -L raspberrypi-kernel-headers | egrep -m1 "/lib/modules/[[:print:]]+/build" | awk -F'/' '{ print $4; }')
   [ "X$VER_RUN" == "X$VER_HDR" ] && {
     return 0
   }


### PR DESCRIPTION
The lib modules folder looks like `/lib/modules/6.1.21-v8+/build`, which means that the previous regex doesn't capture anything after the `-` and therefore it fails to detect the kernel version.
The regex now aligns with the other detection method and this works fine on my machine™