### PR TITLE
Fix kernel panic from sleeping-in-atomic in ALSA trigger callbacks

### DIFF
--- a/ac108.c
+++ b/ac108.c
@@ -446,10 +446,13 @@ static const struct snd_soc_dapm_route ac108_dapm_routes[] = {
 
 static int ac108_multi_write(u8 reg, u8 val, struct ac10x_priv *ac10x) {
 	u8 i;
+	int ret = 0;
 	for (i = 0; i < ac10x->codec_cnt; i++) {
-		ac10x_write(reg, val, ac10x->i2cmap[i]);
+		int r = ac10x_write(reg, val, ac10x->i2cmap[i]);
+		if (r < 0)
+			ret = r;
 	}
-	return 0;
+	return ret;
 }
 
 static int ac108_multi_update_bits(u8 reg, u8 mask, u8 val, struct ac10x_priv *ac10x) {

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -122,6 +122,11 @@ static int seeed_voice_card_startup(struct snd_pcm_substream *substream)
 	snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min = priv->channels_capture_override;
 	snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_max = priv->channels_capture_override;
 
+	/* Drain any pending clock-stop work before starting a new stream.
+	 * cancel_work_sync sleeps, so it must not run under the stream lock;
+	 * the startup callback runs in process context with no spinlock held. */
+	cancel_work_sync(&priv->work_codec_clk);
+
 	return ret;
 }
 
@@ -131,6 +136,11 @@ static void seeed_voice_card_shutdown(struct snd_pcm_substream *substream)
 	struct seeed_card_data *priv =	snd_soc_card_get_drvdata(rtd->card);
 	struct seeed_dai_props *dai_props =
 		seeed_priv_to_props(priv, rtd->num);
+
+	/* Drain deferred clock-stop work before shutdown tears down the codec.
+	 * Without this, ac108_aif_shutdown can race with the workqueue item
+	 * over I2C register writes. Safe here: shutdown runs in process context. */
+	cancel_work_sync(&priv->work_codec_clk);
 
 	snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min = priv->channels_playback_default;
 	snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_max = priv->channels_playback_default;
@@ -208,6 +218,25 @@ static void work_cb_codec_clk(struct work_struct *work)
 	return;
 }
 
+/* prepare: enable codec clocks in process context (outside the stream lock).
+ * The _set_clock functions perform I2C writes that sleep, so they must not
+ * run in the atomic trigger callback.  ac108_set_clock guards on sysclk_en,
+ * so repeated prepare calls are harmless no-ops. */
+static int seeed_voice_card_prepare(struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *dai = snd_soc_rtd_to_codec(rtd, 0);
+
+	if (_set_clock[SNDRV_PCM_STREAM_CAPTURE])
+		_set_clock[SNDRV_PCM_STREAM_CAPTURE](1, substream,
+			SNDRV_PCM_TRIGGER_START, dai);
+	if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK])
+		_set_clock[SNDRV_PCM_STREAM_PLAYBACK](1, substream,
+			SNDRV_PCM_TRIGGER_START, dai);
+
+	return 0;
+}
+
 static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd)
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
@@ -226,16 +255,7 @@ static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd
 	case SNDRV_PCM_TRIGGER_START:
 	case SNDRV_PCM_TRIGGER_RESUME:
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
-		if (cancel_work_sync(&priv->work_codec_clk) != 0) {}
-		#if CONFIG_AC10X_TRIG_LOCK
-		/* I know it will degrades performance, but I have no choice */
-		spin_lock_irqsave(&priv->lock, flags);
-		#endif
-		if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](1, substream, cmd, dai);
-		if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](1, substream, cmd, dai);
-		#if CONFIG_AC10X_TRIG_LOCK
-		spin_unlock_irqrestore(&priv->lock, flags);
-		#endif
+		/* Clock enable moved to seeed_voice_card_prepare (process ctx) */
 		break;
 
 	case SNDRV_PCM_TRIGGER_STOP:
@@ -246,15 +266,12 @@ static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd
 			break;
 		}
 
-		/* interrupt environment */
-		if (in_irq() || in_nmi() || in_serving_softirq()) {
-			priv->try_stop = 0;
-			if (0 != schedule_work(&priv->work_codec_clk)) {
-			}
-		} else {
-			if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
-			if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
-		}
+		/* Always defer clock-stop to the workqueue.  ALSA trigger
+		 * callbacks run under snd_pcm_stream_lock_irq (atomic context)
+		 * regardless of caller.  The _set_clock functions perform I2C
+		 * writes that sleep, so they must never run here directly. */
+		priv->try_stop = 0;
+		schedule_work(&priv->work_codec_clk);
 		break;
 	default:
 		ret = -EINVAL;
@@ -271,6 +288,7 @@ static struct snd_soc_ops seeed_voice_card_ops = {
 	.startup = seeed_voice_card_startup,
 	.shutdown = seeed_voice_card_shutdown,
 	.hw_params = seeed_voice_card_hw_params,
+	.prepare = seeed_voice_card_prepare,
 	.trigger = seeed_voice_card_trigger,
 };
 


### PR DESCRIPTION
Fixes #22

## Problem

`seeed_voice_card_trigger` runs under `snd_pcm_stream_lock_irq` (atomic context) but calls `_set_clock` which performs I2C register writes via `bcm2835_i2c_xfer` → `wait_for_completion_timeout` → `schedule()`. This triggers `BUG: scheduling while atomic` on every stream start and stop, corrupting the kernel scheduler. After ~30–40 seconds of silent corruption, the kernel Oopses (jumps to a userspace address from corrupted saved registers) and panics.

Reproducible on Raspberry Pi 4 with the ReSpeaker 4-Mic Array HAT using any application that opens and closes ALSA capture streams (arecord, PyAudio/PortAudio, etc).

## Root cause

Four sleeping-in-atomic bugs in `seeed_voice_card_trigger`:

1. **TRIGGER_STOP** called `_set_clock(0)` directly when not in IRQ context — but `snd_pcm_stream_lock_irq` is still held, so I2C writes sleep under spinlock
2. **TRIGGER_START** called `_set_clock(1)` under the stream lock — same problem
3. **TRIGGER_START** called `cancel_work_sync` under the stream lock — `cancel_work_sync` can sleep
4. **TRIGGER_START** optionally acquired a second spinlock (`CONFIG_AC10X_TRIG_LOCK`) around the I2C writes

## Fix (commit 1: `seeed-voicecard.c`)

- Move `_set_clock(1)` (clock enable) from `TRIGGER_START` to a new `prepare` callback. The ALSA prepare callback runs in process context outside the stream lock, so I2C writes are safe.
- Change `TRIGGER_STOP` to unconditionally defer `_set_clock(0)` to the system workqueue. The original code only deferred when `in_irq()`, missing the common case where the stream lock is held in process context.
- Add `cancel_work_sync` in `startup` (moved from `TRIGGER_START`) and `shutdown` callbacks to drain deferred work, preventing races with codec teardown.

After this change, `seeed_voice_card_trigger` performs zero sleeping operations in either START or STOP.

## Hardening (commit 2: `ac108.c`)

`ac108_multi_write` discarded I2C write return values, always returning 0. Now propagates errors so callers can detect hardware failures.

## Testing

Tested on Raspberry Pi 4 Model B with ReSpeaker 4-Mic Array HAT, kernel 6.12.75+rpt-rpi-v8.

- **Before fix:** `BUG: scheduling while atomic` on every stream open/close → kernel Oops → panic (100% reproducible)
- **After fix:** 8 clean test cycles (wake word detection → audio capture → STT → shutdown), zero BUG traces, no Oops, no panic. Also tested with Python/PortAudio workarounds removed — clean shutdown via normal ALSA close path.

## Other branches

This fix targets v6.12 but the bug exists on all branches. The changed lines are identical across v6.12, v6.13, and v6.14 (the `rtd->num` → `rtd->id` rename in v6.13 doesn't touch the affected functions). Happy to cherry-pick to other branches if that's helpful.

## Known remaining issue

`ac108_trigger` (the codec DAI trigger in `ac108.c:1074–1081`) acquires `spin_lock_irqsave` and conditionally performs an I2C write if `BCLK_IOEN=1 && LRCK_IOEN=0`. This is a latent sleeping-in-atomic bug, but the guard condition was never true in any test run on the 4-Mic HAT. Fixing it properly requires moving the logic to a codec-level prepare callback. Happy to address in a follow-up if desired.
