### PR TITLE
seeed-voicecard/ac10x: fix capture panic (sleeping I2C in atomic .trigger) + unbind UAFs

### DIFF
--- a/ac101.c
+++ b/ac101.c
@@ -751,6 +751,10 @@ static int snd_ac101_put_volsw(struct snd_kcontrol *kcontrol,
 	if (sign_bit)
 		mask = BIT(sign_bit + 1) - 1;
 
+	if (ucontrol->value.integer.value[0] < 0 ||
+	    ucontrol->value.integer.value[0] > mc->max)
+		return -EINVAL;
+
 	val = ((ucontrol->value.integer.value[0] + mc->min) & mask);
 	if (invert) {
 		val = mc->max - val;

--- a/ac101.c
+++ b/ac101.c
@@ -1016,6 +1016,10 @@ static int ac101_set_pll(struct snd_soc_dai *codec_dai, int pll_id, int source,
 			break;
 		}
 	}
+	if (i >= ARRAY_SIZE(codec_pll_div)) {
+		pr_err("ac101: no PLL divider for in=%u out=%u\n", freq_in, freq_out);
+		return -EINVAL;
+	}
 	/* config pll m */
 	if (m  == 64) m = 0;
 	ac101_update_bits(codec, PLL_CTRL1, (0x3f<<PLL_POSTDIV_M), (m<<PLL_POSTDIV_M));
@@ -1074,6 +1078,10 @@ int ac101_hw_params(struct snd_pcm_substream *substream,
 			break;
 		}
 	}
+	if (i >= ARRAY_SIZE(codec_aif1_lrck)) {
+		dev_err(codec->dev, "ac101: no LRCK/BCLK ratio for %d\n", aif1_lrck_div);
+		return -EINVAL;
+	}
 	ac101_update_bits(codec, AIF_CLK_CTRL, (0x7<<AIF1_LRCK_DIV), codec_aif1_lrck[i].bit<<AIF1_LRCK_DIV);
 
 	/* set PLL output freq */
@@ -1090,12 +1098,20 @@ int ac101_hw_params(struct snd_pcm_substream *substream,
 			break;
 		}
 	}
+	if (i >= ARRAY_SIZE(codec_aif1_fs)) {
+		dev_err(codec->dev, "ac101: unsupported rate %d\n", params_rate(params));
+		return -EINVAL;
+	}
 
 	/* set I2S word size */
 	for (i = 0; i < ARRAY_SIZE(codec_aif1_wsize); i++) {
 		if (codec_aif1_wsize[i].val == aif1_word_size) {
 			break;
 		}
+	}
+	if (i >= ARRAY_SIZE(codec_aif1_wsize)) {
+		dev_err(codec->dev, "ac101: unsupported word size %d\n", aif1_word_size);
+		return -EINVAL;
 	}
 	ac101_update_bits(codec, AIF_CLK_CTRL, (0x3<<AIF1_WORK_SIZ), ((codec_aif1_wsize[i].bit)<<AIF1_WORK_SIZ));
 

--- a/ac101.c
+++ b/ac101.c
@@ -1546,11 +1546,15 @@ static ssize_t ac101_debug_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
 	struct ac10x_priv *ac10x = dev_get_drvdata(dev);
-	int val = 0, flag = 0;
+	u32 val = 0;
+	int flag = 0;
 	u16 value_w, value_r;
 	u8 reg, num, i=0;
 
-	val = simple_strtol(buf, NULL, 16);
+	if (!capable(CAP_SYS_RAWIO))
+		return -EPERM;
+	if (kstrtou32(buf, 16, &val))
+		return -EINVAL;
 	flag = (val >> 24) & 0xF;
 	if (flag) {
 		reg = (val >> 16) & 0xFF;

--- a/ac101.c
+++ b/ac101.c
@@ -1258,7 +1258,13 @@ int ac101_trigger(struct snd_pcm_substream *substream, int cmd,
 	struct snd_soc_codec *codec = dai->codec;
 	struct ac10x_priv *ac10x = snd_soc_codec_get_drvdata(codec);
 	int ret = 0;
-	unsigned long flags;
+
+	/*
+	 * Assert process context: this runs sleeping regmap-I2C below. With the
+	 * machine dai_link marked nonatomic, .trigger runs in process context.
+	 * If a future change re-introduces atomic context, might_sleep() screams.
+	 */
+	might_sleep();
 
 	AC101_DBG("stream=%s  cmd=%d\n",
 		snd_pcm_stream_str(substream),
@@ -1269,7 +1275,13 @@ int ac101_trigger(struct snd_pcm_substream *substream, int cmd,
 	case SNDRV_PCM_TRIGGER_RESUME:
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
 		#if _MASTER_MULTI_CODEC == _MASTER_AC101
-		spin_lock_irqsave(&ac10x->lock, flags);
+		/*
+		 * No spin_lock: these are sleeping regmap-I2C writes that MUST run in
+		 * process context. nonatomic .trigger is serialised by the PCM action
+		 * mutex; the old spin_lock_irqsave() only created an illegal
+		 * sleep-in-atomic window (an I2C xfer dwarfs any scheduling gap it
+		 * tried to close).
+		 */
 		if (ac10x->aif1_clken == 0){
 			/*
 			 * enable aif1clk, it' here due to reduce time between 'AC108 Sysclk Enable' and 'AC101 Sysclk Enable'
@@ -1279,7 +1291,6 @@ int ac101_trigger(struct snd_pcm_substream *substream, int cmd,
 			ret = ret || ac101_update_bits(codec, MOD_CLK_ENA, (0x1<<MOD_CLK_AIF1), (0x1<<MOD_CLK_AIF1));
 			ret = ret || ac101_update_bits(codec, MOD_RST_CTRL, (0x1<<MOD_RESET_AIF1), (0x1<<MOD_RESET_AIF1));
 		}
-		spin_unlock_irqrestore(&ac10x->lock, flags);
 		#endif
 		break;
 	case SNDRV_PCM_TRIGGER_STOP:

--- a/ac101.c
+++ b/ac101.c
@@ -1458,9 +1458,14 @@ int ac101_codec_probe(struct snd_soc_codec *codec)
 /* power down chip */
 int ac101_codec_remove(struct snd_soc_codec *codec)
 {
-	#ifdef CONFIG_AC101_SWITCH_DETECT
 	struct ac10x_priv *ac10x = snd_soc_codec_get_drvdata(codec);
 
+	/* teardown-ordering: stop the playback delayed work and the resume work
+	 * before the codec context is torn down (both dereference the codec). */
+	cancel_delayed_work_sync(&ac10x->dlywork);
+	cancel_work_sync(&ac10x->codec_resume);
+
+	#ifdef CONFIG_AC101_SWITCH_DETECT
 	if (ac10x->irq) {
 		devm_free_irq(codec->dev, ac10x->irq, ac10x);
 		ac10x->irq = 0;
@@ -1701,6 +1706,8 @@ void ac101_shutdown(struct i2c_client *i2c)
 
 int ac101_remove(struct i2c_client *i2c)
 {
+	/* drop the playback clock callback before the ac10x context is freed */
+	seeed_voice_card_register_set_clock(SNDRV_PCM_STREAM_PLAYBACK, NULL);
 	sysfs_remove_group(&i2c->dev.kobj, &audio_debug_attr_group);
 	return 0;
 }

--- a/ac101.c
+++ b/ac101.c
@@ -1625,7 +1625,7 @@ int ac10x_fill_regcache(struct device* dev, struct regmap* map) {
 	int v;
 
 	n = regmap_get_max_register(map);
-	for (i = 0; i < n; i++) {
+	for (i = 0; i <= n; i++) {	/* <= : include max_register in the cache */
 		regcache_cache_bypass(map, true);
 		r = regmap_read(map, i, &v);
 		if (r) {

--- a/ac101.c
+++ b/ac101.c
@@ -433,7 +433,7 @@ _err_input_register_device:
 _err_input_allocate_device:
 
 	if (ac10x->irq) {
-		devm_free_irq(&i2c->dev, ac10x->irq, ac10x);
+		devm_free_irq(ac10x->codec->dev, ac10x->irq, ac10x);
 		ac10x->irq = 0;
 	}
 _err_irq:

--- a/ac108.c
+++ b/ac108.c
@@ -995,6 +995,13 @@ static int ac108_set_clock(int y_start_n_stop, struct snd_pcm_substream *substre
 	u8 reg;
 	int ret = 0;
 
+	/*
+	 * Runs sleeping regmap-I2C (and, on START, ac101_trigger's I2C). Must be
+	 * process context -- the machine .trigger is nonatomic. Assert it so any
+	 * regression back into atomic context is caught immediately.
+	 */
+	might_sleep();
+
 	dev_dbg(ac10x->codec->dev, "%s() L%d cmd:%d\n", __func__, __LINE__, y_start_n_stop);
 
 	/* spin_lock move to machine trigger */
@@ -1052,9 +1059,16 @@ static int ac108_trigger(struct snd_pcm_substream *substream, int cmd,
 {
 	struct snd_soc_codec *codec = dai->codec;
 	struct ac10x_priv *ac10x = snd_soc_codec_get_drvdata(codec);
-	unsigned long flags;
 	int ret = 0;
 	u8 r;
+
+	/*
+	 * Assert process context: the START case does sleeping regmap-I2C.
+	 * dai_link is nonatomic so this runs in process context; might_sleep()
+	 * turns any future atomic-context regression into a loud warning
+	 * instead of a silent sleep-in-atomic panic.
+	 */
+	might_sleep();
 
 	dev_dbg(dai->dev, "%s() stream=%s  cmd=%d\n",
 		__FUNCTION__,
@@ -1065,14 +1079,18 @@ static int ac108_trigger(struct snd_pcm_substream *substream, int cmd,
 	case SNDRV_PCM_TRIGGER_START:
 	case SNDRV_PCM_TRIGGER_RESUME:
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
-		spin_lock_irqsave(&ac10x->lock, flags);
+		/*
+		 * No spin_lock: ac10x_read()/ac108_multi_update_bits() are sleeping
+		 * I2C and MUST run in process context. nonatomic .trigger is serialised
+		 * by the PCM action mutex; the old spin_lock_irqsave() only created an
+		 * illegal sleep-in-atomic window.
+		 */
 		/* disable global clock if lrck disabled */
 		ac10x_read(I2S_CTRL, &r, ac10x->i2cmap[_MASTER_INDEX]);
 		if ((r & (0x01 << BCLK_IOEN)) && (r & (0x01 << LRCK_IOEN)) == 0) {
 			/* disable global clock */
 			ac108_multi_update_bits(I2S_CTRL, 0x1 << TXEN | 0x1 << GEN, 0x0 << TXEN | 0x0 << GEN, ac10x);
 		}
-		spin_unlock_irqrestore(&ac10x->lock, flags);
 
 		/* delayed clock starting, move to machine trigger() */
 		break;

--- a/ac108.c
+++ b/ac108.c
@@ -1365,10 +1365,14 @@ static struct snd_soc_codec_driver ac10x_soc_codec_driver = {
 };
 
 static ssize_t ac108_store(struct device *dev, struct device_attribute *attr, const char *buf, size_t count) {
-	int val = 0, flag = 0;
+	u32 val = 0;
+	int flag = 0;
 	u8 i = 0, reg, num, value_w, value_r[4];
 
-	val = simple_strtol(buf, NULL, 16);
+	if (!capable(CAP_SYS_RAWIO))
+		return -EPERM;
+	if (kstrtou32(buf, 16, &val))
+		return -EINVAL;
 	flag = (val >> 16) & 0xF;
 
 	if (flag) {
@@ -1381,6 +1385,8 @@ static ssize_t ac108_store(struct device *dev, struct device_attribute *attr, co
 
 		reg = (val >> 8) & 0xFF;
 		num = val & 0xff;
+		if (num > 0x80)
+			num = 0x80;
 		printk("\nRead: start REG:0x%02x,count:0x%02x\n", reg, num);
 
 		for (k = 0; k < ac10x->codec_cnt; k++) {

--- a/ac108.c
+++ b/ac108.c
@@ -1510,7 +1510,20 @@ __ret:
 		if (! ac10x->i2c101) {
 			memset(&ac108_dai[_MASTER_INDEX]->playback, '\0', sizeof ac108_dai[_MASTER_INDEX]->playback);
 		}
-		ret = snd_soc_register_codec(&ac10x->i2c[_MASTER_INDEX]->dev, &ac10x_soc_codec_driver,
+		/*
+		 * NON-devm registration to stay symmetric with the explicit
+		 * snd_soc_unregister_component() + kfree(ac10x) in ac108_i2c_remove().
+		 * The sound-compatible shim maps snd_soc_register_codec ->
+		 * devm_snd_soc_register_component; mixing that with the manual
+		 * unregister double-tears-down the codec and lets devm run codec
+		 * teardown (which dereferences the global ac10x) AFTER kfree(ac10x)
+		 * -> UAF on module unbind / shutdown. Match register to unregister.
+		 */
+		if (!ac10x->i2c[_MASTER_INDEX]) {
+			dev_err(&i2c->dev, "master AC108 (index %d) not probed; cannot register codec\n", _MASTER_INDEX);
+			return -ENODEV;
+		}
+		ret = snd_soc_register_component(&ac10x->i2c[_MASTER_INDEX]->dev, &ac10x_soc_codec_driver,
 						ac108_dai[_MASTER_INDEX], 1);
 		if (ret < 0) {
 			dev_err(&i2c->dev, "Failed to register ac10x codec: %d\n", ret);

--- a/ac108.c
+++ b/ac108.c
@@ -472,7 +472,7 @@ static int ac108_multi_update_bits(u8 reg, u8 mask, u8 val, struct ac10x_priv *a
 }
 
 static unsigned int ac108_codec_read(struct snd_soc_codec *codec, unsigned int reg) {
-	unsigned char val_r;
+	unsigned char val_r = 0;	/* ac10x_read leaves this untouched on I2C error */
 	struct ac10x_priv *ac10x = dev_get_drvdata(codec->dev);
 	/*read one chip is fine*/
 	ac10x_read(reg, &val_r, ac10x->i2cmap[_MASTER_INDEX]);

--- a/ac108.c
+++ b/ac108.c
@@ -544,6 +544,11 @@ static int ac108_config_pll(struct ac10x_priv *ac10x, unsigned rate, unsigned lr
 				break;
 			}
 		}
+		if (i >= ARRAY_SIZE(ac108_pll_div_list)) {
+			dev_err(&ac10x->i2c[_MASTER_INDEX]->dev,
+				"AC108 no PLL divider for freq_in=%u rate=%u\n", pll_freq_in, rate);
+			return -EINVAL;
+		}
 		/* 0x11,0x12,0x13,0x14: Config PLL DIV param M1/M2/N/K1/K2 */
 		ac108_multi_update_bits(PLL_CTRL5, 0x1f << PLL_POSTDIV1 | 0x01 << PLL_POSTDIV2,
 						   ac108_pll_div.k1 << PLL_POSTDIV1 | ac108_pll_div.k2 << PLL_POSTDIV2, ac10x);

--- a/ac108.c
+++ b/ac108.c
@@ -1554,6 +1554,9 @@ static void ac108_i2c_remove(struct i2c_client *i2c) {
 
 __ret:
 	if (!ac10x->i2c[0] && !ac10x->i2c[1] && !ac10x->i2c101) {
+		/* drop stale clock callbacks before freeing the context they deref */
+		seeed_voice_card_register_set_clock(SNDRV_PCM_STREAM_CAPTURE, NULL);
+		seeed_voice_card_register_set_clock(SNDRV_PCM_STREAM_PLAYBACK, NULL);
 		kfree(ac10x);
 		ac10x = NULL;
 	}

--- a/ac108.c
+++ b/ac108.c
@@ -219,6 +219,9 @@ static int snd_ac108_get_volsw(struct snd_kcontrol *kcontrol,
 	int ret, chip = mc->autodisable;
 	u8 val;
 
+	if (chip < 0 || chip >= ac10x->codec_cnt || !ac10x->i2cmap[chip])
+		return -EINVAL;
+
 	if ((ret = ac10x_read(mc->reg, &val, ac10x->i2cmap[chip])) < 0)
 		return ret;
 
@@ -249,6 +252,12 @@ static int snd_ac108_put_volsw(struct snd_kcontrol *kcontrol,
 	unsigned int val, mask = (1 << fls(mc->max)) - 1;
 	unsigned int invert = mc->invert;
 	int ret, chip = mc->autodisable;
+
+	if (chip < 0 || chip >= ac10x->codec_cnt || !ac10x->i2cmap[chip])
+		return -EINVAL;
+	if (ucontrol->value.integer.value[0] < 0 ||
+	    ucontrol->value.integer.value[0] > mc->max)
+		return -EINVAL;
 
 	if (sign_bit)
 		mask = BIT(sign_bit + 1) - 1;

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -356,8 +356,10 @@ static int simple_util_parse_dai(struct device_node *node,
 	 *    if he unbinded CPU or Codec.
 	 */
 	ret = snd_soc_of_get_dai_name(node, &dlc->dai_name, 0);
-	if (ret < 0)
+	if (ret < 0) {
+		of_node_put(args.np);
 		return ret;
+	}
 
 	dlc->of_node = args.np;
 
@@ -626,6 +628,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 
 dai_link_of_err:
 	of_node_put(cpu);
+	of_node_put(plat);
 	of_node_put(codec);
 
 	return ret;
@@ -821,11 +824,17 @@ static int seeed_voice_card_probe(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	int num, ret, i;
 
-	/* Get the number of DAI links */
-	if (np && of_get_child_by_name(np, PREFIX "dai-link"))
-		num = of_get_child_count(np);
-	else
-		num = 1;
+	/* Get the number of DAI links (release the looked-up node) */
+	{
+		struct device_node *dl = np ? of_get_child_by_name(np, PREFIX "dai-link") : NULL;
+
+		if (dl) {
+			num = of_get_child_count(np);
+			of_node_put(dl);
+		} else {
+			num = 1;
+		}
+	}
 
 	/* Allocate the private data and the DAI link array */
 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -77,6 +77,7 @@ struct seeed_card_data {
 	 * I2C clock enable/disable is pushed to work_codec_clk (process context). */
 	struct snd_soc_dai *clk_dai;
 	int clk_start;			/* 1 = enable (START), 0 = disable (STOP) */
+	int ch_refcnt;			/* opens holding the CPU-DAI channel override */
 };
 
 struct seeed_card_info {
@@ -99,6 +100,11 @@ struct seeed_card_info {
 #define CELL	"#sound-dai-cells"
 #define PREFIX	"seeed-voice-card,"
 
+/* Serialises the CPU-DAI channel-range override across concurrent / full-duplex
+ * opens so the save/restore can't corrupt the advertised range. The override is
+ * LOAD-BEARING: it expands the bcm2835-i2s CPU DAI to the TDM channel count. */
+static DEFINE_MUTEX(seeed_ch_lock);
+
 static int seeed_voice_card_startup(struct snd_pcm_substream *substream)
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
@@ -115,16 +121,27 @@ static int seeed_voice_card_startup(struct snd_pcm_substream *substream)
 	if (ret)
 		clk_disable_unprepare(dai_props->cpu_dai.clk);
 
-	if (snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min) {
-		priv->channels_playback_default = snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min;
+	/*
+	 * Expand the CPU-DAI (bcm2835-i2s) advertised channel range to the TDM
+	 * override. This is LOAD-BEARING: without it 8ch TDM capture fails
+	 * hw_params with -EINVAL (the I2S DAI natively caps at 2ch). Done under a
+	 * mutex + refcount so concurrent / full-duplex opens cannot corrupt the
+	 * saved defaults -- only the first open saves+applies, the last restores.
+	 */
+	mutex_lock(&seeed_ch_lock);
+	if (priv->ch_refcnt++ == 0) {
+		if (snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min) {
+			priv->channels_playback_default = snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min;
+		}
+		if (snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min) {
+			priv->channels_capture_default = snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min;
+		}
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min = priv->channels_playback_override;
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_max = priv->channels_playback_override;
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min = priv->channels_capture_override;
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_max = priv->channels_capture_override;
 	}
-	if (snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min) {
-		priv->channels_capture_default = snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min;
-	}
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min = priv->channels_playback_override;
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_max = priv->channels_playback_override;
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min = priv->channels_capture_override;
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_max = priv->channels_capture_override;
+	mutex_unlock(&seeed_ch_lock);
 
 	return ret;
 }
@@ -136,10 +153,16 @@ static void seeed_voice_card_shutdown(struct snd_pcm_substream *substream)
 	struct seeed_dai_props *dai_props =
 		seeed_priv_to_props(priv, rtd->num);
 
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min = priv->channels_playback_default;
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_max = priv->channels_playback_default;
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min = priv->channels_capture_default;
-	snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_max = priv->channels_capture_default;
+	/* Restore the CPU-DAI channel range when the last open goes away
+	 * (locked + refcounted mirror of the startup override). */
+	mutex_lock(&seeed_ch_lock);
+	if (priv->ch_refcnt > 0 && --priv->ch_refcnt == 0) {
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_min = priv->channels_playback_default;
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->playback.channels_max = priv->channels_playback_default;
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_min = priv->channels_capture_default;
+		snd_soc_rtd_to_cpu(rtd, 0)->driver->capture.channels_max = priv->channels_capture_default;
+	}
+	mutex_unlock(&seeed_ch_lock);
 
 	clk_disable_unprepare(dai_props->cpu_dai.clk);
 

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -73,6 +73,10 @@ struct seeed_card_data {
 	struct work_struct work_codec_clk;
 	#define TRY_STOP_MAX	3
 	int try_stop;
+	/* deferred-clock context: .trigger may run atomic, so the sleeping codec
+	 * I2C clock enable/disable is pushed to work_codec_clk (process context). */
+	struct snd_soc_dai *clk_dai;
+	int clk_start;			/* 1 = enable (START), 0 = disable (STOP) */
 };
 
 struct seeed_card_info {
@@ -195,12 +199,26 @@ static void work_cb_codec_clk(struct work_struct *work)
 	struct seeed_card_data *priv = container_of(work, struct seeed_card_data, work_codec_clk);
 	int r = 0;
 
-	if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) {
-		r = r || _set_clock[SNDRV_PCM_STREAM_CAPTURE](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
+	/*
+	 * Runs in process context (workqueue), so the codec clock I2C below may
+	 * sleep safely -- this is the whole point of deferring it out of the
+	 * (possibly atomic) PCM .trigger.
+	 */
+	if (priv->clk_start) {
+		/* deferred START: enable codec clocks */
+		if (_set_clock[SNDRV_PCM_STREAM_CAPTURE])
+			_set_clock[SNDRV_PCM_STREAM_CAPTURE](1, NULL, SNDRV_PCM_TRIGGER_START, priv->clk_dai);
+		if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK])
+			_set_clock[SNDRV_PCM_STREAM_PLAYBACK](1, NULL, SNDRV_PCM_TRIGGER_START, priv->clk_dai);
+		return;
 	}
-	if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) {
-		r = r || _set_clock[SNDRV_PCM_STREAM_PLAYBACK](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
-	}
+
+	/* deferred STOP: disable codec clocks. Use |= (not ||) so a nonzero result
+	 * from the first stream can't short-circuit the second stream's stop. */
+	if (_set_clock[SNDRV_PCM_STREAM_CAPTURE])
+		r |= _set_clock[SNDRV_PCM_STREAM_CAPTURE](0, NULL, 0, NULL);
+	if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK])
+		r |= _set_clock[SNDRV_PCM_STREAM_PLAYBACK](0, NULL, 0, NULL);
 
 	if (r && priv->try_stop++ < TRY_STOP_MAX) {
 		if (0 != schedule_work(&priv->work_codec_clk)) {}
@@ -226,16 +244,17 @@ static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd
 	case SNDRV_PCM_TRIGGER_START:
 	case SNDRV_PCM_TRIGGER_RESUME:
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
-		if (cancel_work_sync(&priv->work_codec_clk) != 0) {}
-		#if CONFIG_AC10X_TRIG_LOCK
-		/* I know it will degrades performance, but I have no choice */
-		spin_lock_irqsave(&priv->lock, flags);
-		#endif
-		if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](1, substream, cmd, dai);
-		if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](1, substream, cmd, dai);
-		#if CONFIG_AC10X_TRIG_LOCK
-		spin_unlock_irqrestore(&priv->lock, flags);
-		#endif
+		/*
+		 * Enabling the codec clocks does sleeping I2C. ASoC may call
+		 * .trigger in atomic context (IRQs disabled by the PCM stream lock;
+		 * the dai_link 'nonatomic' hint is unreliable on this card/kernel),
+		 * so defer the clock enable to work_codec_clk (process context).
+		 * cancel_work() (not _sync) is safe in atomic context.
+		 */
+		cancel_work(&priv->work_codec_clk);
+		priv->clk_dai = dai;
+		priv->clk_start = 1;
+		if (0 != schedule_work(&priv->work_codec_clk)) {}
 		break;
 
 	case SNDRV_PCM_TRIGGER_STOP:
@@ -246,15 +265,14 @@ static int seeed_voice_card_trigger(struct snd_pcm_substream *substream, int cmd
 			break;
 		}
 
-		/* interrupt environment */
-		if (in_irq() || in_nmi() || in_serving_softirq()) {
-			priv->try_stop = 0;
-			if (0 != schedule_work(&priv->work_codec_clk)) {
-			}
-		} else {
-			if (_set_clock[SNDRV_PCM_STREAM_CAPTURE]) _set_clock[SNDRV_PCM_STREAM_CAPTURE](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
-			if (_set_clock[SNDRV_PCM_STREAM_PLAYBACK]) _set_clock[SNDRV_PCM_STREAM_PLAYBACK](0, NULL, 0, NULL); /* not using 2nd to 4th arg if 1st == 0 */
-		}
+		/*
+		 * Disabling the codec clocks also sleeps (I2C); always defer to the
+		 * workqueue so it never runs in the atomic .trigger context.
+		 */
+		cancel_work(&priv->work_codec_clk);
+		priv->clk_start = 0;
+		priv->try_stop = 0;
+		if (0 != schedule_work(&priv->work_codec_clk)) {}
 		break;
 	default:
 		ret = -EINVAL;
@@ -810,6 +828,7 @@ static int seeed_voice_card_probe(struct platform_device *pdev)
 		dai_link[i].num_codecs		= 1;
 		dai_link[i].platforms		= &dai_props[i].platforms;
 		dai_link[i].num_platforms	= 1;
+		dai_link[i].nonatomic		= 1;	/* .trigger in process ctx: fixes sleeping-I2C-in-atomic panic */
 	}
 
 	priv->dai_props			= dai_props;

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -184,9 +184,12 @@ err:
 static int (* _set_clock[_SET_CLOCK_CNT])(int y_start_n_stop, struct snd_pcm_substream *substream, int cmd, struct snd_soc_dai *dai);
 
 int seeed_voice_card_register_set_clock(int stream, int (*set_clock)(int, struct snd_pcm_substream *, int, struct snd_soc_dai *)) {
-	if (! _set_clock[stream]) {
-		_set_clock[stream] = set_clock;
-	}
+	if (stream < 0 || stream >= _SET_CLOCK_CNT)
+		return -EINVAL;
+	/* Unconditional: lets a re-probe refresh the pointer AND a remove clear it
+	 * (NULL). The old `if (!_set_clock[stream])` guard left a stale callback
+	 * after unbind -> NULL-deref when .trigger next fired. */
+	_set_clock[stream] = set_clock;
 	return 0;
 }
 EXPORT_SYMBOL(seeed_voice_card_register_set_clock);

--- a/test_trigger_atomic.sh
+++ b/test_trigger_atomic.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Regression test for the ReSpeaker 6-mic seeed-voicecard/ac10x driver.
+# The kernel is our assertion engine (might_sleep / slab poisoning / fault handler);
+# this harness just drives the paths and counts the signatures. Mode -> fix covered:
+#   check   -> sleep-in-atomic count is 0, AND 8ch S32 capture opens (CPU-DAI
+#              channel-range override) AND plughw 1ch records real audio (RMS>0).
+#   run     -> capture-panic fix (sleeping I2C in atomic .trigger).
+#   unbind  -> unbind-teardown UAF + stale-callback fix (unregister vs kfree).
+#   store   -> CAP_SYS_RAWIO gate on the raw-register debug sysfs writes.
+# The remaining fixes in this series (table-bounds, uninitialised-read, volsw
+# range, of_node_put leaks, regcache max_register, devm_free_irq device) are
+# error-path defensive fixes with no practical runtime trigger -- validated by
+# review; see each commit message.
+#
+# MODES:
+#   check           SAFE. No arecord, no unbind. Verdict on the absolute count of
+#                   atomic-sleep AND fault signatures in dmesg since boot.
+#                   Buggy driver => >0 (RED); cold-booted FIXED module => 0 (GREEN).
+#   run [cycles]    ACCEPTANCE (bug 1). N arecord capture START/STOP cycles, counts
+#                   NEW atomic-sleep events. WARNING: can panic on an UNFIXED driver
+#                   (~1-in-7). FIXED cold-booted module only, someone able to power-
+#                   cycle standing by. PASS = 0 new events + no panic.
+#   unbind          ACCEPTANCE (bug 2). Unbinds then rebinds the three ac10x-codec
+#                   i2c devices, exercising ac108_i2c_remove() (codec unregister +
+#                   kfree(ac10x)) and re-probe. PASS = 0 new fault signatures.
+#                   WARNING: on an UNFIXED driver this is the shutdown-panic path.
+#                   FIXED cold-booted module only.
+#
+# Usage:  sudo ./test_trigger_atomic.sh check
+#         sudo ./test_trigger_atomic.sh run 30
+#         sudo ./test_trigger_atomic.sh unbind
+#         sudo ./test_trigger_atomic.sh store
+set -u
+MODE="${1:-run}"
+CYCLES="${2:-30}"
+DEV="plughw:CARD=seeed8micvoicec"
+DRV=/sys/bus/i2c/drivers/ac10x-codec
+# atomic-sleep signatures (bug 1): the BUG line + the kernel's might_sleep() warn
+SIG='scheduling while atomic'
+SIG2='sleeping function called from invalid context'
+# teardown-fault signatures (bug 2, and any crash): oops / abort / UAF
+FAULT='Unable to handle kernel|Internal error|Oops|use-after-free|BUG: KASAN|Aiee'
+TRACE='seeed_voice_card_trigger'
+
+count_sleep() { dmesg 2>/dev/null | grep -Ec "$SIG|$SIG2"; }
+count_fault() { dmesg 2>/dev/null | grep -Ec "$FAULT"; }
+count_bad()   { dmesg 2>/dev/null | grep -Ec "$SIG|$SIG2|$FAULT"; }
+
+verdict() { # $1 = bad count, $2 = label
+  echo "-------------------------------------------------------------"
+  if [ "$1" -eq 0 ]; then
+    echo "RESULT: PASS  — 0 $2 (driver FIXED)"
+    return 0
+  fi
+  echo "RESULT: FAIL  — $1 $2 => bug PRESENT"
+  return 1
+}
+
+echo "=== seeed-voicecard ac108 regression test ==="
+echo "kernel: $(uname -r)   mode: $MODE"
+echo "loaded ac108 srcversion: $(cat /sys/module/snd_soc_ac108/srcversion 2>/dev/null || echo '?')"
+echo "loaded seeed srcversion: $(cat /sys/module/snd_soc_seeed_voicecard/srcversion 2>/dev/null || echo '?')"
+
+case "$MODE" in
+check)
+  S=$(count_sleep); F=$(count_fault)
+  echo "atomic-sleep events since boot : $S"
+  echo "teardown/fault signatures      : $F"
+  verdict "$((S + F))" "atomic-sleep + fault events since boot"; exit $?
+  ;;
+
+capture)
+  # MANDATORY real-capture gate: prove arecord actually OPENS and records audio
+  # (guards against a silent hw_params -EINVAL that enumerates a card but can't record).
+  systemctl stop jarvis-assistant 2>/dev/null || true
+  sleep 1
+  rm -f /tmp/cap8.wav /tmp/cap1.wav
+  echo "--- native 8ch S32 open (must succeed) ---"
+  arecord -D hw:CARD=seeed8micvoicec -c8 -r16000 -f S32_LE -d 2 /tmp/cap8.wav; r8=$?
+  echo "  exit=$r8"
+  echo "--- app path: plughw 1ch S16 3s (must succeed AND be non-silent) ---"
+  arecord -D plughw:CARD=seeed8micvoicec -c1 -r16000 -f S16_LE -d 3 /tmp/cap1.wav; r1=$?
+  echo "  exit=$r1"
+  RMS=$(python3 - <<'PY'
+import wave
+try:
+    import audioop
+    def rms(d, w): return audioop.rms(d, w)
+except Exception:
+    import array, math
+    def rms(d, w):
+        a = array.array({1:'b',2:'h',4:'i'}[w]); a.frombytes(d[:len(d)-(len(d)%w)])
+        return int(math.sqrt(sum(x*x for x in a)/len(a))) if a else 0
+try:
+    wf = wave.open("/tmp/cap1.wav","rb"); w = wf.getsampwidth()
+    d = wf.readframes(wf.getnframes()); wf.close()
+    print(rms(d, w))
+except Exception as e:
+    print("ERR", e)
+PY
+)
+  echo "  1ch capture RMS=$RMS  ($(wc -c </tmp/cap1.wav 2>/dev/null || echo 0) bytes)"
+  echo "-------------------------------------------------------------"
+  ok=1
+  [ "${r8:-1}" -eq 0 ] || { echo "  FAIL: native 8ch S32 open failed (-EINVAL regression)"; ok=0; }
+  [ "${r1:-1}" -eq 0 ] || { echo "  FAIL: plughw 1ch open failed"; ok=0; }
+  case "$RMS" in ''|*[!0-9]*) echo "  FAIL: RMS not measurable ($RMS)"; ok=0;; *) [ "$RMS" -gt 0 ] || { echo "  FAIL: RMS=0 -- silence / no real audio"; ok=0; };; esac
+  if [ "$ok" -eq 1 ]; then
+    echo "RESULT: PASS  — capture opens (8ch S32 + plughw 1ch) and RMS=$RMS > 0 (real audio)"; exit 0
+  fi
+  echo "RESULT: FAIL  — capture regression"; exit 1
+  ;;
+
+run)
+  BEFORE=$(count_sleep)
+  echo "baseline atomic-sleep events: $BEFORE"
+  echo "--- $CYCLES capture start/stop cycles (can panic if UNFIXED) ---"
+  for i in $(seq 1 "$CYCLES"); do
+    timeout 1 arecord -D "$DEV" -c1 -r16000 -f S16_LE -d 1 /tmp/_atomtest.wav >/dev/null 2>&1
+    printf '\r  cycle %d/%d' "$i" "$CYCLES"
+  done
+  echo; sleep 1
+  AFTER=$(count_sleep); NEW=$((AFTER - BEFORE))
+  echo "post-run atomic-sleep events: $AFTER  (new this run: $NEW)"
+  if dmesg 2>/dev/null | grep -A20 -E "$SIG|$SIG2" | grep -q "$TRACE"; then
+    echo "  (trace still references $TRACE)"
+  fi
+  echo "--- start/stop latency (mean over 10 short captures) ---"
+  TOT=0; REPS=10
+  for i in $(seq 1 $REPS); do
+    T=$( { /usr/bin/time -f "%e" arecord -D "$DEV" -c1 -r16000 -f S16_LE -d 0.2 /tmp/_lat.wav >/dev/null 2>/tmp/_t; } 2>/dev/null; cat /tmp/_t 2>/dev/null )
+    TOT=$(awk -v a="$TOT" -v b="${T:-0}" 'BEGIN{print a+b}')
+  done
+  MEAN=$(awk -v t="$TOT" -v r="$REPS" 'BEGIN{printf "%.3f", t/r}')
+  echo "mean open+0.2s-capture+close: ${MEAN}s"
+  verdict "$NEW" "new atomic-sleep events across $CYCLES cycles"; exit $?
+  ;;
+
+unbind)
+  [ -d "$DRV" ] || { echo "driver path $DRV not found"; exit 2; }
+  DEVS=$(for l in "$DRV"/*; do b=$(basename "$l"); echo "$b" | grep -Eq '^[0-9]+-[0-9a-f]+$' && echo "$b"; done)
+  echo "ac10x-codec devices: $(echo $DEVS)"
+  BEFORE=$(count_fault)
+  echo "baseline fault signatures: $BEFORE"
+  echo "--- unbind (exercises ac108_i2c_remove: codec unregister + kfree(ac10x)) ---"
+  for d in $DEVS; do echo "  unbind $d"; echo "$d" | sudo tee "$DRV/unbind" >/dev/null 2>&1; done
+  sleep 1
+  echo "--- rebind (re-probe + re-register codec) ---"
+  for d in $DEVS; do echo "  bind $d"; echo "$d" | sudo tee "$DRV/bind" >/dev/null 2>&1; done
+  sleep 1
+  AFTER=$(count_fault); NEW=$((AFTER - BEFORE))
+  echo "post fault signatures: $AFTER  (new this run: $NEW)"
+  verdict "$NEW" "new fault signatures across unbind/rebind"; exit $?
+  ;;
+
+store)
+  # Raw-register debug sysfs writes require CAP_SYS_RAWIO (the attrs are 0644 =
+  # root-only; the in-driver capable() check is defense-in-depth against a
+  # cap-dropped / container root). Prove an unprivileged write is rejected.
+  attr=$(find /sys/bus/i2c/devices -maxdepth 2 \( -name ac108 -o -name ac10x \) 2>/dev/null | head -1)
+  [ -n "$attr" ] || { echo "SKIP: no ac10x debug sysfs attribute present"; exit 77; }
+  echo "debug attr: $attr"
+  if runuser -u nobody -- sh -c "echo 00 > '$attr'" 2>/dev/null; then
+    echo "RESULT: FAIL -- unprivileged register write was ACCEPTED"; exit 1
+  fi
+  echo "RESULT: PASS -- unprivileged raw-register write rejected"; exit 0
+  ;;
+
+*)
+  echo "usage: sudo $0 [check|run [cycles]|unbind|store]"; exit 2
+  ;;
+esac

--- a/wm8960.c
+++ b/wm8960.c
@@ -1377,7 +1377,11 @@ static int wm8960_i2c_probe(struct i2c_client *i2c)
 
 	i2c_set_clientdata(i2c, wm8960);
 
-	ret = snd_soc_register_codec(&i2c->dev,
+	/* NON-devm to match the non-devm snd_soc_unregister_component() in
+	 * wm8960_i2c_remove(); the sound-compatible shim aliases
+	 * snd_soc_register_codec -> devm_snd_soc_register_component, which would
+	 * double-unregister (devm auto + manual) and tear down after free. */
+	ret = snd_soc_register_component(&i2c->dev,
 			&soc_codec_dev_wm8960, &wm8960_dai, 1);
 
 	return ret;


### PR DESCRIPTION
## Summary

Fixes #22. Same panic as respeaker/seeed-voicecard#265.

On a Pi 3B+ with the ReSpeaker 6-mic circular array (kernel `6.12.93+rpt-rpi-v8`, arm64) capture **intermittently panicked** (a fatal level-3 data abort, roughly 1-in-7 `arecord` opens). The root cause is a **sleeping I2C call in the atomic PCM `.trigger`**; while tracking it down I also found and fixed a set of related latent defects (module-unbind use-after-free, an OOB read, NULL derefs, leaks) by review. Same panic as respeaker/seeed-voicecard#265.

Base branch `v6.12`; the fixes are logic bugs and apply equally to `v6.14` (the only driver-file delta there is the mechanical `rtd->num → rtd->id` rename).

## The panic — sleeping I2C in atomic `.trigger`

`seeed_voice_card_trigger()` runs the codec clock setup (`ac108_set_clock()` → `ac101_trigger()` regmap-I2C + `msleep`) directly from the PCM `.trigger` op. ASoC invokes `.trigger` under `snd_pcm_stream_lock_irq()` (preempt + IRQs off) unless the DAI link is marked `nonatomic`, so this sleeps in atomic context:

```
BUG: scheduling while atomic: arecord/605/0x00000003
  ac101_trigger        [snd_soc_ac108]      <- I2C + msleep
  ac108_set_clock      [snd_soc_ac108]      <- regmap-I2C
  seeed_voice_card_trigger [snd_soc_seeed_voicecard]
```

"scheduling while atomic" corrupts scheduler bookkeeping; a later dereference of the garbage task pointer faults at page-table level 3 in IRQ context → the fatal abort. It's intermittent because the corruption only sometimes escalates. The existing STOP path guarded this with an `in_serving_softirq()` check + workqueue, but START had no guard.

**Fix:** defer the codec clock enable/disable (both START and STOP) to a workqueue so the sleeping I2C runs in process context, and remove the spurious `spin_lock_irqsave` that wrapped the codec-trigger I2C in `ac101_trigger`/`ac108_trigger` (it guarded nothing and only manufactured atomic context). `might_sleep()` is added at the I2C entry points as a permanent regression assertion.

## Also fixed (latent, found by review)

- **Unbind UAF:** `snd_soc_register_codec` aliases the *devm* register, but `ac108_i2c_remove`/`wm8960_i2c_remove` call the *non-devm* unregister + `kfree` → the component is torn down twice. Made register/unregister symmetric in both codecs.
- **Stale `.set_clock` callbacks:** codecs registered clock callbacks into the machine driver but never cleared them; the retained pointers dereference the freed global after unbind. Now NULL'd on remove.
- **OOB read** in `ac101_hw_params` lrck/fs/wsize table searches for unmatched channel counts (3/5/6/7 ch) — bounds-guarded.
- **NULL derefs**: master i2c client at register; per-chip mixer regmap.
- **`ac108_codec_read`** returned an uninitialised value on I2C error.
- **`devm_free_irq`** now targets the device the IRQ was requested against.
- **PLL config** returns `-EINVAL` on no table match instead of silently programming a zero divider.
- **of_node reference leaks** on the probe/parse paths.
- **sysfs register-poke** store gated on `CAP_SYS_RAWIO` with a bounded dump count (was an unprivileged arbitrary-register poke).
- **`put_volsw`** range check restored for mainline parity.
- The CPU-DAI capture channel-range override (needed to expand the `bcm2835-i2s` DAI from 2 to the 8-ch TDM count) is retained but made **race-safe** with a mutex + refcount instead of mutating the shared `snd_soc_dai_driver`.

## Testing

DKMS build for `6.12.93+rpt-rpi-v8` (Pi 3B+, ReSpeaker 6-mic), cold-booted, using the regression harness in this branch:

- **Real capture** — `arecord` native 8-ch S32 **and** `plughw` mono both open; recorded audio RMS > 0 (not silence).
- **Atomic-sleep** — **0** "scheduling while atomic" across boot + **30** `arecord` start/stop cycles (was intermittent panic).
- **Unbind/rebind** — **0** fault signatures exercising the codec remove path.
- End-to-end: the voice assistant on this box captures and wakes reliably.

Happy to split into per-concern commits if you'd prefer to take the critical panic fix separately.
