### PR TITLE
seeed-voicecard/ac101: don't reset "DAC volume" on every playback stream close

### DIFF
--- a/ac101.c
+++ b/ac101.c
@@ -913,7 +913,14 @@ int ac101_aif_mute(struct snd_soc_dai *codec_dai, int mute)
 
 	AC101_DBG("mute=%d\n",  mute);
 
-	ac101_write(codec, DAC_VOL_CTRL, mute? 0: 0xA0A0);
+	/*
+	 * Do NOT clobber DAC_VOL_CTRL here. DAC_VOL_CTRL is *also* the
+	 * ALSA "DAC volume" mixer control, so writing 0 on mute (and a hardcoded
+	 * 0xA0A0 on unmute) overrode the user/alsactl setting and, worse, zeroed the
+	 * volume on EVERY stream close -> all playback after the first was silent.
+	 * Muting is already done by disabling the speaker (SPKOUT_CTRL) and gating
+	 * the amp in the mute branch below; the DAC level is left to the ALSA control.
+	 */
 
 	if (!mute) {
 		#if _MASTER_MULTI_CODEC != _MASTER_AC101
@@ -1419,7 +1426,14 @@ int ac101_codec_probe(struct snd_soc_codec *codec)
 
 	/*enable this bit to prevent leakage from ldoin*/
 	ac101_update_bits(codec, ADDA_TUNE3, (0x1<<OSCEN), (0x1<<OSCEN));
-	ac101_write(codec, DAC_VOL_CTRL, 0);
+	/*
+	 * Probe with an AUDIBLE DAC volume (0xA0A0 ~= 0 dB), NOT 0 (-119 dB).
+	 * We removed the 0xA0A0-on-unmute write in ac101_aif_mute (it clobbered the ALSA
+	 * "DAC volume" control every stream-close), so this probe write is now the initial
+	 * value the control mirrors. Leaving it at 0 would silence playback out-of-the-box
+	 * on any image without a saved alsactl asound.state. alsactl restore still overrides.
+	 */
+	ac101_write(codec, DAC_VOL_CTRL, 0xA0A0);
 
 	/* customized get/put inteface */
 	for (ret = 0; ret < ARRAY_SIZE(ac101_controls); ret++) {

--- a/test_dac_volume_persist.sh
+++ b/test_dac_volume_persist.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Regression test for the DAC-volume-clobber fix in ac101.c (ac10x codec).
+#
+# BUG (pre-fix): ac101_aif_mute() wrote DAC_VOL_CTRL on every mute/unmute — 0 on mute,
+#   a hardcoded 0xA0A0 on unmute. DAC_VOL_CTRL is *also* the ALSA "DAC volume" mixer
+#   control, so the driver zeroed the user/alsactl-set volume on EVERY playback stream
+#   close. Symptom: the first sound plays, every sound after it is silent (DAC at 0),
+#   and any amixer/alsactl "DAC volume" setting is overridden the moment a stream ends.
+#
+# FIX: ac101_aif_mute() no longer touches DAC_VOL_CTRL (muting is done by gating the
+#   speaker/amp); the DAC level is owned purely by the ALSA control. probe() sets one
+#   audible default. See the ac101.c comments on aif_mute and codec_probe.
+#
+# TEST: set "DAC volume" to a known level, force a playback stream open+close, and assert
+#   the control is UNCHANGED afterwards. The ALSA control state IS the assertion.
+#     buggy module  -> volume reset (drops to 0% / probe default) on close  => FAIL (RED)
+#     fixed module  -> volume held across the close                         => PASS (GREEN)
+#
+# Usage:  sudo ./test_dac_volume_persist.sh            # one open/close cycle
+#         CYCLES=5 sudo ./test_dac_volume_persist.sh   # repeat N times
+#         TESTVOL='70%' sudo ./test_dac_volume_persist.sh
+#
+# NOTE: if a userspace mixer/daemon holds the playback stream open forever (which itself
+#   masks the bug), stop it first so this test can actually open+close a stream.
+set -u
+CARD="${CARD:-0}"
+DEV="${DEV:-plughw:CARD=seeed8micvoicec}"
+CTL="DAC volume"
+TESTVOL="${TESTVOL:-80%}"
+CYCLES="${CYCLES:-1}"
+
+get() { amixer -c "$CARD" sget "$CTL" 2>/dev/null | grep -o '\[[0-9]*%\]' | head -1; }
+
+if ! amixer -c "$CARD" sget "$CTL" >/dev/null 2>&1; then
+  echo "SKIP: no '$CTL' control on card $CARD (is the ac10x codec loaded?)"; exit 77
+fi
+
+amixer -c "$CARD" sset "$CTL" "$TESTVOL" >/dev/null 2>&1
+set_to=$(get)
+echo "set '$CTL' -> $set_to; running $CYCLES playback open/close cycle(s) on $DEV"
+
+fail=0
+for i in $(seq 1 "$CYCLES"); do
+  before=$(get)
+  # 0.1s of silence: opens a playback stream and closes it (fires aif_mute on close)
+  head -c 3200 /dev/zero | aplay -q -D "$DEV" -f S16_LE -r 16000 -c 1 -t raw 2>/dev/null
+  after=$(get)
+  if [ "$before" != "$after" ]; then
+    echo "  cycle $i: FAIL  $before -> $after  (DAC volume clobbered on stream close)"
+    fail=1
+  else
+    echo "  cycle $i: ok    held $after"
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: DAC volume persisted across stream close (clobber fix present)"
+  exit 0
+else
+  echo "FAIL: DAC volume was reset on stream close (buggy/pre-fix module loaded)"
+  exit 1
+fi


### PR DESCRIPTION
## Problem

On the ReSpeaker 6-mic circular array (ac10x codec), **only the first sound after boot plays — every playback after that is silent**, and any `amixer` / `alsactl` "DAC volume" setting is overridden the moment a stream ends.

## Root cause

`ac101_aif_mute()` writes `DAC_VOL_CTRL` on every mute/unmute — `0` on mute, a hardcoded `0xA0A0` on unmute. But `DAC_VOL_CTRL` is *also* the register backing the ALSA **"DAC volume"** mixer control, so the codec zeroes the user/alsactl-set DAC volume on **every playback stream close**. `ac101_codec_probe()` also seeds it to `0` (full attenuation), so a fresh image with no saved `asound.state` is silent out of the box.

## Fix

- `ac101_aif_mute()` no longer touches `DAC_VOL_CTRL`. Muting is already handled by disabling the speaker (`SPKOUT_CTRL`) and gating the amp in the mute branch; the DAC *level* is left to the ALSA control where it belongs.
- `ac101_codec_probe()` seeds an audible `0xA0A0` (~0 dB) instead of `0`. `alsactl restore` still overrides it.

## Test

`test_dac_volume_persist.sh`: set "DAC volume" to a known level, cycle a playback stream open/close, assert the level is unchanged. Pre-fix the level resets on close (FAIL); fixed it holds (PASS).

## Verified

Pi 3B+, ReSpeaker 6-mic, kernel `6.12.93+rpt-rpi-v8`, DKMS build, cold-booted. Before: `DAC volume` 90% → 0% on the first stream close; after: holds across repeated open/close cycles and multi-clip playback stays audible.

Distinct from #45 / #46 (those fix the capture-path panic). This is playback-only and touches just `ac101.c`; it applies verbatim to v6.14+ (identical `ac101.c`) if you'd like a port.

@HinTak — would appreciate a review when you have a moment. Thanks for maintaining this driver!
