### PR TITLE
Support Linux kernel >=v6.15

### DIFF
--- a/ac101.c
+++ b/ac101.c
@@ -1150,7 +1150,7 @@ int ac101_set_dai_fmt(struct snd_soc_dai *codec_dai, unsigned int fmt)
 	reg_val = ac101_read(codec, AIF_CLK_CTRL);
 	reg_val &= ~(0x1<<AIF1_MSTR_MOD);
 	switch(fmt & SND_SOC_DAIFMT_MASTER_MASK) {
-	case SND_SOC_DAIFMT_CBM_CFM:   /* codec clk & frm master, ap is slave*/
+	case SND_SOC_DAIFMT_CBP_CFP:   /* codec clk & frm master, ap is slave*/
 		#if _MASTER_MULTI_CODEC == _MASTER_AC101
 		pr_info("AC101 as Master\n");
 		reg_val |= (0x0<<AIF1_MSTR_MOD);
@@ -1158,7 +1158,7 @@ int ac101_set_dai_fmt(struct snd_soc_dai *codec_dai, unsigned int fmt)
 		#else
 		pr_info("AC108 as Master\n");
 		#endif
-	case SND_SOC_DAIFMT_CBS_CFS:   /* codec clk & frm slave, ap is master*/
+	case SND_SOC_DAIFMT_CBC_CFC:   /* codec clk & frm slave, ap is master*/
 		pr_info("AC101 as Slave\n");
 		reg_val |= (0x1<<AIF1_MSTR_MOD);
 		break;

--- a/ac108.c
+++ b/ac108.c
@@ -853,7 +853,7 @@ static int ac108_set_fmt(struct snd_soc_dai *dai, unsigned int fmt) {
 	dev_dbg(dai->dev, "%s\n", __FUNCTION__);
 
 	switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
-	case SND_SOC_DAIFMT_CBM_CFM:    /*AC108 Master*/
+	case SND_SOC_DAIFMT_CBP_CFP:    /*AC108 Master*/
 		if (! ac10x->i2c101 || _MASTER_MULTI_CODEC == _MASTER_AC108) {
 			dev_dbg(dai->dev, "AC108 set to work as Master\n");
 			/**
@@ -869,7 +869,7 @@ static int ac108_set_fmt(struct snd_soc_dai *dai, unsigned int fmt) {
 			dev_dbg(dai->dev, "used as slave when AC101 is master\n");
 		}
 		fallthrough;
-	case SND_SOC_DAIFMT_CBS_CFS:    /*AC108 Slave*/
+	case SND_SOC_DAIFMT_CBC_CFC:    /*AC108 Slave*/
 		dev_dbg(dai->dev, "AC108 set to work as Slave\n");
 		/**
 		 * 0x30:chip is slave mode, BCLK & LRCK input,enable SDO1_EN and 

--- a/ac108.c
+++ b/ac108.c
@@ -272,7 +272,7 @@ static int snd_ac108_put_volsw(struct snd_kcontrol *kcontrol,
 	.tlv.p = (tlv_array), \
 	.info = snd_soc_info_volsw, .get = snd_ac108_get_volsw,\
 	.put = snd_ac108_put_volsw, \
-	.private_value = SOC_SINGLE_VALUE(reg, shift, max, invert, chip) }
+	.private_value = SOC_SINGLE_VALUE(reg, shift, 0, max, invert, chip) }
 
 /* single ac108 */
 static const struct snd_kcontrol_new ac108_snd_controls[] = {

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -540,8 +540,7 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 	if (ret < 0)
 		goto dai_link_of_err;
 
-	ret = simple_util_set_dailink_name(dev, dai_link,
-						"%s-%s",
+	dai_link->name = devm_kasprintf(dev, GFP_KERNEL, "%s-%s",
 						dai_link->cpus->dai_name,
 						#if _SINGLE_CODEC
 						dai_link->codecs->dai_name
@@ -549,8 +548,11 @@ static int seeed_voice_card_dai_link_of(struct device_node *node,
 						dai_link->codecs[0].dai_name
 						#endif
 	);
-	if (ret < 0)
+	if (!dai_link->name) {
+		ret = -ENOMEM;
 		goto dai_link_of_err;
+	}
+	dai_link->stream_name = dai_link->name;
 
 	dai_link->ops = &seeed_voice_card_ops;
 	dai_link->init = seeed_voice_card_dai_init;
@@ -670,9 +672,11 @@ static int seeed_voice_card_parse_of(struct device_node *node,
 			goto card_parse_end;
 	}
 
-	ret = simple_util_parse_card_name(&priv->snd_card, PREFIX);
-	if (ret < 0)
+	ret = snd_soc_of_parse_card_name(&priv->snd_card, PREFIX "name");
+	if (ret < 0) {
+		dev_err(dev, "Failed to parse name");
 		goto card_parse_end;
+	}
 
 	ret = seeed_voice_card_parse_aux_devs(node, priv);
 

--- a/wm8960.c
+++ b/wm8960.c
@@ -534,10 +534,10 @@ static int wm8960_set_dai_fmt(struct snd_soc_dai *codec_dai,
 
 	/* set master/slave audio interface */
 	switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
-	case SND_SOC_DAIFMT_CBM_CFM:
+	case SND_SOC_DAIFMT_CBP_CFP:
 		iface |= 0x0040;
 		break;
-	case SND_SOC_DAIFMT_CBS_CFS:
+	case SND_SOC_DAIFMT_CBC_CFC:
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
- tested build-only on v6.15
- tested `arecord` on  `6.18.34+rpt-rpi-v8` with Raspberry Pi 4 and ReSpeaker 6-mic Array